### PR TITLE
Fix file regexp pattern in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Syntax:
   uses: xalvarez/prevent-file-change-action@v1
   with:
     githubToken: ${{ secrets.GITHUB_TOKEN }}
-    pattern: .*.example
+    pattern: .*\.example
     trustedAuthors: xalvarez
 ```
 


### PR DESCRIPTION
See https://github.com/kimai/kimai/actions/runs/7385039079/job/20089038083

<img width="614" alt="Bildschirmfoto 2024-01-02 um 15 05 12" src="https://github.com/xalvarez/prevent-file-change-action/assets/533162/d9cd7be2-cc7d-46ad-9405-afad5dd1bc28">

The pull request has only these files changed: https://github.com/kimai/kimai/pull/4514/files

<img width="320" alt="Bildschirmfoto 2024-01-02 um 15 05 48" src="https://github.com/xalvarez/prevent-file-change-action/assets/533162/b325d4dc-c2e7-45c0-a784-36653e41e4d8">

The "b**lock**s.html.twig" file triggers here, because I blindly followed the (wrong pattern?) in the README.

The pattern `.*.lock` should only match files that end on `.lock` (like `symfony.lock`, `composer.lock`, `yarn.lock`).

For testing: https://regex101.com/r/mTsQJG/1

Maybe we can further improve on my suggestion, as I am not the biggest regex friend 😁 

The README says
> In the example above, files with .example extension won't be allowed to be changed.

But the regex also matches `1example.txt`.

So maybe the pattern `.*\.example$`. is even better?